### PR TITLE
Fix "live now" and "starting soon" badges

### DIFF
--- a/source/video.css
+++ b/source/video.css
@@ -6,6 +6,7 @@ ytd-compact-video-renderer:not(:hover) ytd-channel-name, ytd-compact-video-rende
 	background: var(--ext-yt-blocker-color) !important;
 	border-radius: 3px;
 	pointer-events: none;
+	border-color: var(--ext-yt-blocker-color) !important;
 }
 ytd-compact-video-renderer:not(:hover) span#video-title, ytd-compact-video-renderer:not(:hover) #metadata-line > span {
 	color: transparent;


### PR DESCRIPTION
This adds support for hiding borders of ‘live now’ and ‘starting soon’ badges on a video page.

Today I stumbled upon red lines in the recommendations sidebar on a video page:
![youtube-live-now](https://user-images.githubusercontent.com/971092/115375797-6bde5580-a1ce-11eb-8b3c-2b7202a1254a.png)
Turns out this styling will appear for some badges. The ‘offending CSS of YouTube’ is as follows:

```
.badge-style-type-live-now.ytd-badge-supported-renderer,
.badge-style-type-starting-soon.ytd-badge-supported-renderer {
    background: transparent;
    color: var(--yt-spec-brand-link-text);
    border: 1px solid var(--yt-spec-brand-link-text);
}
```

I dove into the CSS of the extension and this is the simplest solution I could find. I’ve only updated the source file, so a new build will have to be made for a new release of the extension.